### PR TITLE
io.cozy.contacts doctype proposal

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Table of contents
 - [Albums](io.cozy.photos.albums.md): photos albums
 - [Apps](io.cozy.apps.md): installed apps
 - [Bank](io.cozy.bank.md): banking related data
+- [Contacts](io.cozy.contacts.md): instance owner contacts
 - [Files](io.cozy.files.md): files documents
 - [Konnectors](io.cozy.konnectors.md): installed Konnectors
 - [Settings](io.cozy.settings.md): instance settings

--- a/docs/io.cozy.contacts.md
+++ b/docs/io.cozy.contacts.md
@@ -1,0 +1,40 @@
+[Table of contents](README.md#table-of-contents)
+
+# Cozy Contacts doctype
+
+## `io.cozy.contacts`
+
+The `io.cozy.contacts` doctype is loosely based on the [vCard RFC](https://tools.ietf.org/html/rfc6350), in that some of the attributes have been renamed for clarity. The attributes with a `?` are optional.
+
+- `fullname?`: {string} Unstructured representation of the name (example: `"Dr. Gregory House, M.D."`)
+- `name?`: {object} Optional structured representation of the name, with the following possible attributes:
+  - `familyName?`: {string} (example: `"House"`)
+  - `givenName?`: {string} (example: `"Gregory"`)
+  - `additionalName?`: {string} (example: `"J."`)
+  - `namePrefix?`: {string} (example: `"Dr."`)
+  - `nameSuffix?`: {string} (example: `"III"`)
+- `email`: {array} An array of email addresses objects with the following attributes:
+  - `address`: {string} Email adress
+  - `type?`: {string} Programmatic type of email (`"work"`, `"home"`, `"other"`)
+  - `label?`: {string} A user-provided localized type of email (example: `"Work"`)
+  - `primary?`: {boolean} Indicates a preferred-use address
+- `address?`: {array} An array of postal addresses objects with the following attributes:
+  - `street?`: {string}
+  - `pobox?`: {string}
+  - `city?`: {string}
+  - `region?`: {string}
+  - `postcode?`: {string}
+  - `country?`: {string}
+  - `type?`: {string} Programmatic type of email (`"work"`, `"home"`, `"other"`)
+  - `primary?`: {boolean} Indicates a preferred-use address
+  - `label?`: {string}
+  - `formattedAddress?`: {string} Unstructured version of the address
+- `phone?`: {array} An array of phone number objects with the following attributes:
+  - `number`: {string}
+  - `type?`: {string} Programmatic type of phone number (`"work"`, `"home"`, `"mobile"`, `"fax"`, `"other"`)
+  - `label?`: {string} A user-provided localized type of phone number (example: `"Work"`)
+  - `primary?`: {boolean} Indicates a preferred-use number
+- `_cozy?`: {array} An array of cozy instances with the following attributes:
+  - `url`: {string}
+  - `label?`: {string} A user-provided localized type of instance
+  - `primary?`: {boolean} Indicates a preferred-use instance


### PR DESCRIPTION
Here is a proposal for contacts. Nothing definitive, but I wish to dray your attention to the `_cozy` attribute I proposed. My reasoning is that a field for a Cozy instance is not standard in any way (think vCard), so it's probably better to flag it as non standard. vCard use X- attributes, but I thought a underscore is a better alternative.