### PR TITLE
Update remotes doctypes for LMDMF since cozy-stack PR857

### DIFF
--- a/com.omdbapi.img/request
+++ b/com.omdbapi.img/request
@@ -1,1 +1,1 @@
-GET https://img.omdbapi.com/?{{params}}
+GET https://img.omdbapi.com/?apikey={{apikey}}&i={{i}}&h={{h}}

--- a/org.musicbrainz.release-group/request
+++ b/org.musicbrainz.release-group/request
@@ -1,1 +1,1 @@
-GET https://musicbrainz.org/ws/2/release-group/{{rgid}}/?fmt=json&{{params}}
+GET https://musicbrainz.org/ws/2/release-group/{{rgid}}/?fmt=json&inc={{inc}}&status={{status}}

--- a/org.musicbrainz.release/request
+++ b/org.musicbrainz.release/request
@@ -1,1 +1,1 @@
-GET https://musicbrainz.org/ws/2/release/{{rid}}/?fmt=json&{{params}}
+GET https://musicbrainz.org/ws/2/release/{{rid}}/?fmt=json&inc={{inc}}

--- a/org.wikidata.wbsearchentities/request
+++ b/org.wikidata.wbsearchentities/request
@@ -1,1 +1,1 @@
-GET https://www.wikidata.org/w/api.php?action=wbsearchentities&format=json&{{params}}
+GET https://www.wikidata.org/w/api.php?action=wbsearchentities&format=json&search={{search}}&language={{language}}&type={{type}}&limit={{limit}}

--- a/org.wikimedia.uploads/request
+++ b/org.wikimedia.uploads/request
@@ -1,1 +1,0 @@
-GET https://upload.wikimedia.org/{{path}}

--- a/org.wikipedia.en.api.parse.images/request
+++ b/org.wikipedia.en.api.parse.images/request
@@ -1,0 +1,1 @@
+GET https://en.wikipedia.org/w/api.php?action=parse&format=json&prop=images&page={{page}}

--- a/org.wikipedia.en.api.query.imageinfo/request
+++ b/org.wikipedia.en.api.query.imageinfo/request
@@ -1,0 +1,1 @@
+GET https://en.wikipedia.org/w/api.php?action=query&format=json&prop=imageinfo&iiprop=url&titles={{titles}}

--- a/org.wikipedia.en.api/request
+++ b/org.wikipedia.en.api/request
@@ -1,1 +1,0 @@
-GET https://en.wikipedia.org/w/api.php?{{params}}

--- a/org.wikipedia.fr.api.parse.text/request
+++ b/org.wikipedia.fr.api.parse.text/request
@@ -1,0 +1,1 @@
+GET https://fr.wikipedia.org/w/api.php?action=parse&format=json&prop=text&section={{section}}&disablelimitreport={{disablelimitreport}}&disableeditsection={{disableeditsection}}&disabletoc={{disabletoc}}&page={{page}}

--- a/org.wikipedia.fr.api/request
+++ b/org.wikipedia.fr.api/request
@@ -1,1 +1,0 @@
-GET https://fr.wikipedia.org/w/api.php?{{params}}


### PR DESCRIPTION
Removed wikimedia uploads, as indeterminate path length can't be used anymore ( '/' is escaped automatically)