### PR TITLE
Remove settings from README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,5 +10,4 @@ Table of contents
 - [Notifications](io.cozy.notifications.md): notifications made by the apps
 - [Photos Albums](io.cozy.photos.albums.md): photos albums
 - [Remote requests](io.cozy.remote.requests.md): logs of requests via the remote doctypes
-- [Settings](io.cozy.settings.md): instance settings
 - [Sessions Logins](io.cozy.sessions.logins.md): sessions logins entry


### PR DESCRIPTION
The file it was linked to was no longer available in the trunk