### PR TITLE
feat: add groupAmount to bills

### DIFF
--- a/docs/io.cozy.bills.md
+++ b/docs/io.cozy.bills.md
@@ -10,6 +10,7 @@
 - `vendor`: {string} - Vendor which issued the bill
 - `amount`: {number}
 - `originalAmount`: Original amount in case of a partial refund
+- `groupAmount`: Group amount in case this bill was part of a grouped refund
 - `plan`: {string}
 - `pdfurl`: {string} - The associated file
 - `binaryId`: {string}


### PR DESCRIPTION
`groupAmount` is used to match credit operations to a bundle refund that result in a larger bank transaction.