### PR TITLE
Make all contact fields optionnal

### DIFF
--- a/docs/io.cozy.contacts.md
+++ b/docs/io.cozy.contacts.md
@@ -13,9 +13,9 @@ The `io.cozy.contacts` doctype is loosely based on the [vCard RFC](https://tools
   - `additionalName?`: {string} (example: `"J."`)
   - `namePrefix?`: {string} (example: `"Dr."`)
   - `nameSuffix?`: {string} (example: `"III"`)
-- `birthday`: {date} (example: `"1959-05-15"`)
-- `note`: {string}
-- `email`: {array} An array of email addresses objects with the following attributes:
+- `birthday?`: {date} (example: `"1959-05-15"`)
+- `note?`: {string}
+- `email?`: {array} An array of email addresses objects with the following attributes:
   - `address`: {string} Email adress
   - `type?`: {string} Programmatic type of email (`"work"`, `"home"`, `"other"`)
   - `label?`: {string} A user-provided localized type of email (example: `"Work"`)


### PR DESCRIPTION
`birthday` and `note` are obviously optionnal fields and should have been from the start.
`email` was the only mandatory field because contacts were coming from sharings. However now that we have a contacts app, we can totally have a contact with no email.