### PR TITLE
fix: remove $ on io.cozy.bank.balancehistories relationships property

### DIFF
--- a/docs/io.cozy.bank.md
+++ b/docs/io.cozy.bank.md
@@ -129,7 +129,7 @@ This doctype stores a year of daily balances :
   "metadata": {
     "version": 1
   },
-  "$relationships": {
+  "relationships": {
     "account": {
       "data": {
         "_id": "f1aacd3254509687c07e48279b42f3de",


### PR DESCRIPTION
We decided to remove this `$` since it's a pain to make queries with it.