### PR TITLE
feat: Add autocategorization remote doctype

### DIFF
--- a/cc.cozycloud.autocategorization/request
+++ b/cc.cozycloud.autocategorization/request
@@ -1,0 +1,4 @@
+POST https://bank-autocategorization.cozycloud.cc/contribute/
+Content-Type: application/json
+
+{{data}}

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ Table of contents
 ## Cozy doctypes
 
 - [Accounts](io.cozy.accounts.md): Konnector accounts
+- [Autocategorization](cc.cozycloud.autocategorization.md): Auto categorization remote doctype
 - [Bank](io.cozy.bank.md): banking related data
 - [Bills](io.cozy.bills.md): bills
 - [Payslips](io.cozy.payslips.md): payslips
@@ -37,7 +38,7 @@ Every doctype should have `metadata` fields.
 ## Date format
 
 Date should be formatted in [ISO8601](https://fr.wikipedia.org/wiki/ISO_8601) :
- 
+
 * `2017-04-22T01:00:00-05:00` ✅
 * `2017-04-22T01:00:00Z` ✅
 * `2017-04-22 01:00` ❌

--- a/docs/cc.cozycloud.autocategorization.md
+++ b/docs/cc.cozycloud.autocategorization.md
@@ -1,0 +1,21 @@
+[Table of contents](README.md#table-of-contents)
+
+# Auto categorization remote doctype
+
+The `cc.cozycloud.autocategorization` remote doctype is used to anonymously and securely
+send the user's bank transactions to an API when he/she enabled the corresponding setting
+in the Banks app.
+
+`cc.cozycloud.autocategorization` sends an array of
+[`io.cozy.bank.operations`](io.cozy.bank.md#iocozybankoperations), but removes some
+properties to anonymize the data. The following properties are kept:
+
+- `amount`
+- `date`
+- `label`
+- `automaticCategoryId`
+- `manualCategoryId`
+- `cozyCategoryId`
+- `cozyCategoryProba`
+- `localCategoryId`
+- `localCategoryProba`


### PR DESCRIPTION
Add the remote doctype used to send categorized transactions to the auto categorization API.