### PR TITLE
Doc: Update links between contacts and groups

### DIFF
--- a/docs/io.cozy.contacts.md
+++ b/docs/io.cozy.contacts.md
@@ -41,6 +41,11 @@ The `io.cozy.contacts` doctype is loosely based on the [vCard RFC](https://tools
   - `label?`: {string} A user-provided localized type of instance
   - `primary?`: {boolean} Indicates a preferred-use instance
 - `groups`: {array} An array containing a list of ids of `io.cozy.contacts.groups` documents that this contact is part of
+- `relationships`: {object} links between documents
+  - `groups`: {object} groups the contact belongs to
+    - `data`: {array} list of groups
+      - `_id`: {string} id of the io.cozy.contacts.groups document
+      - `_type`: {string} doctype "io.cozy.contacts.groups" 
 - `metadata`: {object}
   - `version`: {integer} Used for migrations. Current version is **1**
 

--- a/docs/io.cozy.contacts.md
+++ b/docs/io.cozy.contacts.md
@@ -40,7 +40,6 @@ The `io.cozy.contacts` doctype is loosely based on the [vCard RFC](https://tools
   - `url`: {string}
   - `label?`: {string} A user-provided localized type of instance
   - `primary?`: {boolean} Indicates a preferred-use instance
-- `groups`: {array} An array containing a list of ids of `io.cozy.contacts.groups` documents that this contact is part of
 - `relationships`: {object} links between documents
   - `groups`: {object} groups the contact belongs to
     - `data`: {array} list of groups


### PR DESCRIPTION
Change how contacts reference their groups. It now conforms to the standard way to link documents in Cozy