### PR TITLE
doc: Remove redundant data

### DIFF
--- a/docs/io.cozy.contacts.md
+++ b/docs/io.cozy.contacts.md
@@ -6,7 +6,6 @@
 
 The `io.cozy.contacts` doctype is loosely based on the [vCard RFC](https://tools.ietf.org/html/rfc6350), in that some of the attributes have been renamed for clarity. The attributes with a `?` are optional.
 
-- `fullname?`: {string} Unstructured representation of the name (example: `"Dr. Gregory House, M.D."`)
 - `name?`: {object} Optional structured representation of the name, with the following possible attributes:
   - `familyName?`: {string} (example: `"House"`)
   - `givenName?`: {string} (example: `"Gregory"`)


### PR DESCRIPTION
With two data that cover the same domain, the risk is heavy to have a desynchronization.
What to do if two authorities say something different?

In such a context, I want to talk about `fullname` that seems to be a view of `[namePrefix,givenName,additionalName,familyName,nameSuffix].join(" ")`.

Be free to close this PR if you think I am wrong, but do not hesitate to explain the main idea.