### PR TITLE
fix: Remove payslip reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,6 @@
 - [Autocategorization](cc.cozycloud.autocategorization.md): Auto categorization remote doctype
 - [Bank](io.cozy.bank.md): banking related data
 - [Bills](io.cozy.bills.md): bills
-- [Payslips](io.cozy.payslips.md): payslips
 - [Contacts](io.cozy.contacts.md): instance owner contacts
 - [Files](io.cozy.files.md): files documents
 - [Konnectors](io.cozy.konnectors): Connectors

--- a/toc.yml
+++ b/toc.yml
@@ -7,7 +7,6 @@
 - Contacts: ./docs/io.cozy.contacts.md
 - Files: ./docs/io.cozy.files.md
 - Notifications: ./docs/io.cozy.notifications.md
-- Payslips: ./docs/io.cozy.payslips.md
 - Remote requests: ./docs/io.cozy.remote.requests.md
 - Session logins: ./docs/io.cozy.sessions.logins.md
 - Sharings: ./docs/io.cozy.sharings.md


### PR DESCRIPTION
Doc for payslips has been removed. This makes the documentation build [fail](https://travis-ci.org/cozy/cozy.github.io/builds/465282168#L606). This PR removes the references to the payslip doctype.