### PR TITLE
Fix contact metadata

### DIFF
--- a/docs/io.cozy.contacts.md
+++ b/docs/io.cozy.contacts.md
@@ -54,7 +54,13 @@ The `io.cozy.contacts` doctype is loosely based on the [vCard RFC](https://tools
 
 - `trashed`: {boolean} is `true` if the contact is marked for removal and will be deleted soon (e.g. after remote deletion is confirmed)
 
--   `me`: {boolean} whether the contact matches the cozy owner (defaults to `false`)
+- `me`: {boolean} whether the contact matches the cozy owner (defaults to `false`)
+
+- `metadata`: {object} previous metadata information.
+
+  - `cozy`: {boolean} whether the contact has been created by cozy
+  - `google`: {object} Google metadata
+  - `version`: {integer} used for migrations. Current version is **1**
 
 - `cozyMetaData`: {object}
 

--- a/docs/io.cozy.contacts.md
+++ b/docs/io.cozy.contacts.md
@@ -40,6 +40,7 @@ The `io.cozy.contacts` doctype is loosely based on the [vCard RFC](https://tools
   - `url`: {string}
   - `label?`: {string} A user-provided localized type of instance
   - `primary?`: {boolean} Indicates a preferred-use instance
+- `company`: {string} Company
 - `relationships`: {object} links between documents
 
   - `groups`: {object} groups the contact belongs to


### PR DESCRIPTION
- `company` field was missing in `io.cozy.contacts`
- we previously removed `metadata` field from spec (in https://github.com/cozy/cozy-doctypes/commit/95bf4142280024d6d314b507e718bbcbd7762dd0 ) but in the end it has been kept during migration