### PR TITLE
Clarify io.cozy.contacts.sync.lastSync field

### DIFF
--- a/docs/io.cozy.contacts.md
+++ b/docs/io.cozy.contacts.md
@@ -71,7 +71,7 @@ The `io.cozy.contacts` doctype is loosely based on the [vCard RFC](https://tools
     - `ded4265b38c54b0683408c76d9ebd`: {object} id of the sourceContactsAccount
 
       - `konnector`: {string} example : `"google"`
-      - `lastSync`: {date} (example: `"2018-10-19T10:58:37.025688+02:00"`)
+      - `lastSync`: {date} (example: `"2018-10-19T10:58:37.025688+02:00"`) Last time a sync task updated this contact
       - `contactsAccountsId`: {string} id of the io.cozy.contacts.accounts object
       - `id`: {string} id of the remote object
       - `remoteRev`: {string} latest rev of the remote object


### PR DESCRIPTION
[Context for this change here](https://github.com/konnectors/toutatice/pull/23#issuecomment-483149685).

This makes `lastSync` a bit like `updatedByApps`, but otherwise we would need to constantly update contacts only to update this field, which is a lot of queries for no good reason.