### PR TITLE
Clarify frequency attribute in docs/io.cozy.konnectors.md

### DIFF
--- a/docs/io.cozy.konnectors.md
+++ b/docs/io.cozy.konnectors.md
@@ -21,7 +21,7 @@ The available attributes in a `io.cozy.konnectors` document are :
 * `doctypes`
 * `editor`
 * `fields`
-* `frequency`
+* `frequency` - Value can be: `['hourly', 'daily', 'weekly', 'monthly']`
 * `icon`
 * `langs`
 * `language`


### PR DESCRIPTION
- Adds allowed values for the frequency attribute, found in [cozy-home/ducks/triggers/index.js](https://github.com/cozy/cozy-home/blob/master/src/ducks/triggers/index.js#L4)