### PR TITLE
fix: Remove query string in cc.cozycloud.sentry

### DIFF
--- a/cc.cozycloud.sentry/request
+++ b/cc.cozycloud.sentry/request
@@ -1,4 +1,4 @@
-POST https://sentry.cozycloud.cc/api/{{project}}/store/?sentry_version={{sentry_version}}&sentry_client={{sentry_client}}&sentry_key={{sentry_key}}
+POST https://sentry.cozycloud.cc/api/{{project}}/store/
 X-Sentry-Auth: Sentry sentry_version={{sentry_version}}, sentry_client={{sentry_client}}, sentry_timestamp=1503522542, sentry_key={{sentry_key}}, sentry_secret={{sentry_secret}}
 
 {{data}}


### PR DESCRIPTION
The Sentry API does not accept receiving auth data in both query string
and HTTP headers. Using HTTP headers is recommended by Sentry, so we use
it. See
https://docs.sentry.io/development/sdk-dev/overview/#authentication for
more informations.