### PR TITLE
fix: io.cozy.contacts birthday format

### DIFF
--- a/docs/io.cozy.contacts.md
+++ b/docs/io.cozy.contacts.md
@@ -13,7 +13,7 @@ The `io.cozy.contacts` doctype is loosely based on the [vCard RFC](https://tools
   - `additionalName?`: {string} (example: `"J."`)
   - `namePrefix?`: {string} (example: `"Dr."`)
   - `nameSuffix?`: {string} (example: `"III"`)
-- `birthday?`: {date} (example: `"1959-05-15"`)
+- `birthday?`: {date} (example: `"1980-04-22T01:00:00Z"`)
 - `note?`: {string}
 - `email?`: {array} An array of email addresses objects with the following attributes:
   - `address`: {string} Email adress


### PR DESCRIPTION
Fixed the example to be coherent with https://github.com/cozy/cozy-doctypes#date-format