### PR TITLE
docs: Add links to toc.yml

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,14 +3,14 @@
 ## Cozy doctypes
 
 - [Accounts](io.cozy.accounts.md): Konnector accounts
-- [Apps](io.cozy.apps.md): Apps
-- [Bank](io.cozy.bank.md): banking related data
-- [Bills](io.cozy.bills.md): bills
-- [Contacts](io.cozy.contacts.md): instance owner contacts
-- [Files](io.cozy.files.md): files documents
+- [Apps](io.cozy.apps.md): Apps installed in the Cozy
+- [Bank](io.cozy.bank.md): Banking related data
+- [Bills](io.cozy.bills.md): Bills
+- [Contacts](io.cozy.contacts.md): Contacts
+- [Files](io.cozy.files.md): Files
 - [Files_metadatas](io.cozy.files_metadata.md): Metadatas about files
-- [Konnectors](io.cozy.konnectors.md): Connectors
-- [Notifications](io.cozy.notifications.md): notifications made by the apps
+- [Connectors](io.cozy.konnectors.md): Connectors installed in the cozy
+- [Notifications](io.cozy.notifications.md): Notifications made by the apps (Email or Push notifications)
 - [Permissions](io.cozy.permissions.md): Permissions of the instance
 - [Photos Albums](io.cozy.photos.albums.md): photos albums
 - [Procedures](io.cozy.procedures.md): Administrative procedures

--- a/toc.yml
+++ b/toc.yml
@@ -1,6 +1,6 @@
 - README: ./docs/README.md
 - Accounts: ./docs/io.cozy.accounts.md
-- Albums: ./docs/io.cozy.photos.albums.md
+- Apps: ./docs/io.cozy.apps.md
 - Banking doctypes: ./docs/io.cozy.bank.md
 - Bills: ./docs/io.cozy.bills.md
 - Connectors: ./docs/io.cozy.konnectors.md
@@ -10,5 +10,22 @@
 - Notifications: ./docs/io.cozy.notifications.md
 - Remote requests: ./docs/io.cozy.remote.requests.md
 - Session logins: ./docs/io.cozy.sessions.logins.md
+- Permissions: ./docs/io.cozy.permissions.md
+- Photos Albums: ./docs/io.cozy.photos.albums.md
+- Procedures: ./docs/io.cozy.procedures.md
+- Sessions Logins: ./docs/io.cozy.sessions.logins.md
+- Settings: ./docs/io.cozy.settings.md
 - Sharings: ./docs/io.cozy.sharings.md
+- Accounts Types: ./docs/io.cozy.account_types.md
+- Autocategorization: ./docs/cc.cozycloud.autocategorization.md
+- Exports: ./docs/io.cozy.exports.md
+- Jobs: ./docs/io.cozy.jobs.md
+- OAuth Clients: ./docs/io.cozy.oauth.clients.md
+- OAuth Access Codes: ./docs/io.cozy.oauth.access_codes.md
 - Triggers: ./docs/io.cozy.triggers.md
+- Triggers state: ./docs/io.cozy.triggers.state.md
+- Remote requests: ./docs/io.cozy.remote.requests.md
+- Sessions: ./docs/io.cozy.sessions.md
+- Shared: ./docs/io.cozy.shared.md
+- Terms: ./docs/io.cozy.terms.md
+- Bets Unibet: ./docs/com.unibet.bets


### PR DESCRIPTION
Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [x] in the `Readme.md` index page
- [x] in the `toc.yml` page

---

Added missing links from Readme.md to toc.yml