### PR TITLE
Precision for owner in io-cozy-sharings

### DIFF
--- a/docs/io.cozy.sharings.md
+++ b/docs/io.cozy.sharings.md
@@ -14,7 +14,7 @@ documents and files from her cozy instance to other people.
   and why)
 - a flag `active` that says if the sharing is currently active for at least
   one member
-- a flag `owner`, true for the document on the cozy of the sharer, and false
+- a flag `owner`, true for the document on the cozy of the sharer, and absent
   on the other cozy instance
 * a flag `open_sharing`:
   * `true` if any member of the sharing can add a new recipient


### PR DESCRIPTION
In `io.cozy.sharings`, the `owner` property is never `false`. It is `true` for the document on the cozy of the sharer or absent on the other cozy instance. 
