### PR TITLE
Add the doctypes for bitwarden (ciphers and folders)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ This repository is where the declaration of remote doctypes is done. Read more a
 ## External doctypes
 
 - [bitwarden ciphers](com.bitwarden.ciphers.md): Ciphers for bitwarden clients
+- [bitwarden folders](com.bitwarden.folders.md): Folders for bitwarden clients
 - [Bets Unibet](com.unibet.bets.md): Bets from Unibet website
 
 ## Generic model

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ This repository is where the declaration of remote doctypes is done. Read more a
 
 ## External doctypes
 
+- [bitwarden ciphers](com.bitwarden.ciphers.md): Ciphers for bitwarden clients
 - [Bets Unibet](com.unibet.bets.md): Bets from Unibet website
 
 ## Generic model

--- a/docs/com.bitwarden.ciphers.md
+++ b/docs/com.bitwarden.ciphers.md
@@ -8,7 +8,7 @@ The `com.bitwarden.ciphers` doctype is used to store secret things for the
 1. Login
 2. Secure note
 3. Card
-4. Identity.
+4. Identity
 
 ## Attributes
 

--- a/docs/com.bitwarden.ciphers.md
+++ b/docs/com.bitwarden.ciphers.md
@@ -1,0 +1,62 @@
+[Table of contents](README.md#table-of-contents)
+
+# Bitwarden ciphers
+
+The `com.bitwarden.ciphers` doctype is used to store secret things for the
+[bitwarden clients](https://bitwarden.com/). There are 4 types of ciphers:
+
+1. Login
+2. Secure note
+3. Card
+4. Identity.
+
+## Attributes
+
+* `type`: {int} - from 1 for login to 4 for identity
+* `shared_with_cozy`: {bool} - true if the cipher is in the cozy organization
+* `favorite`: {bool} - true if the cipher has been marked as a favorite in a client
+* `name`: {string} - the name of the cipher, encrypted as a cipherString with AES
+* `notes`: {string} - some notes about the cipher, encrypted
+* `folder_id`: {string} - the identifier of a bitwarden folder
+* `login`: {object} - an object only used when type is 1 (see below)
+* `data`: {object} - a map of encrypted properties on the cipher
+* `fields`: {array} - a list of objects, with `type`, `name`, and `value` (encrypted)
+* `cozyMetadata`: {object} - the [cozyMetadata](README.md#document-metadata)
+
+### Logins
+
+When the cipher has type 1 (login), the `login` is an object with these fields:
+
+- `uris`: {array} - an array of `uri` (an encrypted string) and `match` (`null` or a number)
+- `username`: {string} - the encrypted username/login/identifier
+- `password`: {string} - the encrypted password
+- `passwordRevisionDate`: {date} - the last time the password was changed
+- `totp`: {string} - the encrypted information about the second factor (2FA)
+
+## Example
+
+```json
+{
+  "_id": "44907c0262681483ab53e944fa077496",
+  "_rev": "1-ded69b8f2b34ba6095f7637868453138",
+  "type": 1,
+  "shared_with_cozy": false,
+  "name": "2.ygPX4ld50/Z2kEjdEWvhHg==|1nxqZVBUcnMk9bxzQDJyqQ==|HRjAlp45dJ2RBRBGY6yvDvZseOD49oimuUU5y12MuHk=",
+  "login": {
+    "uris": [
+      {
+        "uri": "2.DNrdKV2iNY+RtJbqFnPu7Q==|vhIZA5pXFngJRCnZlYjTmQV0ybQdJ6lNzt1CoTauwVI=|PiDEUFpvEaJtrKADSnyuqALajPHnDmfQsiDLEqF+3YY="
+      }
+    ],
+    "username": "2.+uazyy7smAtIToJfqcS8yw==|IhmkZ0OHV+kX7txsPsSztA==|tDc1Zgknyl/JMn/O44hWZBaywSsHGeRGvK7ffEr5SdM=",
+    "password": "2.L+41A7ch4GypwrIFXG5vkA==|S3eFnoNtk1IpsT4gcfcNrw==|lqdBTpSHKqTJtgBBXBXqm2K249AF1gZMec4cFf5gqR0="
+  },
+  "fields": null,
+  "cozyMetadata": {
+    "doctypeVersion": "1",
+    "metadataVersion": 1,
+    "createdAt": "2019-09-24T15:48:19.55593719+02:00",
+    "updatedAt": "2019-09-24T15:48:19.55593719+02:00"
+  }
+}
+```

--- a/docs/com.bitwarden.ciphers.md
+++ b/docs/com.bitwarden.ciphers.md
@@ -12,7 +12,7 @@ The `com.bitwarden.ciphers` doctype is used to store secret things for the
 
 ## Attributes
 
-* `type`: {int} - from 1 for login to 4 for identity
+* `type`: {int} - from 1 for login to 4 for identity (see the list above)
 * `shared_with_cozy`: {bool} - true if the cipher is in the cozy organization
 * `favorite`: {bool} - true if the cipher has been marked as a favorite in a client
 * `name`: {string} - the name of the cipher, encrypted as a cipherString with AES

--- a/docs/com.bitwarden.ciphers.md
+++ b/docs/com.bitwarden.ciphers.md
@@ -17,7 +17,7 @@ The `com.bitwarden.ciphers` doctype is used to store secret things for the
 * `favorite`: {bool} - true if the cipher has been marked as a favorite in a client
 * `name`: {string} - the name of the cipher, encrypted as a cipherString with AES
 * `notes`: {string} - some notes about the cipher, encrypted
-* `folder_id`: {string} - the identifier of a bitwarden folder
+* `folder_id`: {string} - the identifier of a [bitwarden folder](./com.bitwarden.folders.md)
 * `login`: {object} - an object only used when type is 1 (see below)
 * `data`: {object} - a map of encrypted properties on the cipher
 * `fields`: {array} - a list of objects, with `type`, `name`, and `value` (encrypted)

--- a/docs/com.bitwarden.folders.md
+++ b/docs/com.bitwarden.folders.md
@@ -1,0 +1,27 @@
+[Table of contents](README.md#table-of-contents)
+
+# Bitwarden folders
+
+The `com.bitwarden.folders` doctype is used to organize
+[ciphers](./com.bitwarden.ciphers.md).
+
+## Attributes
+
+* `name`: {string} - the name of the folder, encrypted as a cipherString with AES
+* `cozyMetadata`: {object} - the [cozyMetadata](README.md#document-metadata)
+
+## Example
+
+```json
+{
+  "_id": "44907c0262681483ab53e944fa0782e1",
+  "_rev": "1-63242020f047a03e828514af2546c914",
+  "name": "2.wqUYK+tfBUcUospPv28uhw==|FCcImzd1G6Xq8sO1mF9+Xw==|am84ofcVS+NM0fWhm4WIECC+iBQ9fldOtVy1JrfTmyg=",
+  "cozyMetadata": {
+    "doctypeVersion": "1",
+    "metadataVersion": 1,
+    "createdAt": "2019-09-24T15:51:29.320878421+02:00",
+    "updatedAt": "2019-09-24T15:51:29.320878421+02:00"
+  }
+}
+```

--- a/toc.yml
+++ b/toc.yml
@@ -30,4 +30,5 @@
 - Shared: ./docs/io.cozy.shared.md
 - Terms: ./docs/io.cozy.terms.md
 - Bitwarden ciphers: ./docs/com.bitwarden.ciphers.md
+- Bitwarden folders: ./docs/com.bitwarden.folders.md
 - Bets Unibet: ./docs/com.unibet.bets.md

--- a/toc.yml
+++ b/toc.yml
@@ -29,4 +29,5 @@
 - Sessions: ./docs/io.cozy.sessions.md
 - Shared: ./docs/io.cozy.shared.md
 - Terms: ./docs/io.cozy.terms.md
+- Bitwarden ciphers: ./docs/com.bitwarden.ciphers.md
 - Bets Unibet: ./docs/com.unibet.bets.md


### PR DESCRIPTION
Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [X] in the `Readme.md` index page
- [X] in the `toc.yml` page
