### PR TITLE
docs: Use correct format for vaultCipher relationship

### DIFF
--- a/docs/io.cozy.accounts.md
+++ b/docs/io.cozy.accounts.md
@@ -15,7 +15,7 @@ Accounts can be managed in [Cozy-Home](http://github.com/cozy/cozy-home/) (via [
 - `state`: {string} The account state is used to communicate between the konnector and [Harvest](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-harvest-lib) to ask for a needed 2FA Code or to tell to reset the konnector session for example. Here are the used values for now:
     - `TWOFA_NEEDED`: The service is asking for a Two Factor connexion and the related code (sent by the service) must be provided by the user. This status can be further precised with its type. This allows the UI presented to the user to have custom messages, depending on the type of two factor authentication required by the vendor.
         - `TWOFA_NEEDED.EMAIL`: If the two factor authentication is done by email
-        - `TWOFA_NEEDED.SMS`: If the two factor authentication is done by SMS 
+        - `TWOFA_NEEDED.SMS`: If the two factor authentication is done by SMS
     - `TWOFA_NEEDED_RETRY`: The 2FA code provided by the user is wrong, the user can retry by providing a new one. `TWO_FA_NEEDED_RETRY.EMAIL` and `TWO_FA_NEEDED_RETRY.SMS` can also be used.
     - `RESET_SESSION`: By finding this state, the konnector should reset the login session if there is one stored and reset the state.
 - `twoFACode`: When a 2FA code is asked by the service, [Harvest](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-harvest-lib) will ask the user for it from and send it to the konnector via this attribute.
@@ -59,9 +59,13 @@ An account can be synced in a password manager. In that case, the `vaultCipher` 
 {
   "relationships": {
     "vaultCipher": {
-      "_id": "123abc",
-      "_type": "com.bitwarden.ciphers",
-      "_protocol": "bitwarden"
+      "data": [
+        {
+          "_id": "123abc",
+          "_type": "com.bitwarden.ciphers",
+          "_protocol": "bitwarden"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
See https://github.com/cozy/cozy-doctypes/blob/master/docs/README.md#external-relationships

Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [ ] in the `Readme.md` index page
- [ ] in the `toc.yml` page
