### PR TITLE
docs: Update account's vaultCipher relationships format

### DIFF
--- a/docs/io.cozy.accounts.md
+++ b/docs/io.cozy.accounts.md
@@ -64,13 +64,11 @@ An account can be synced in a password manager. In that case, the `vaultCipher` 
 {
   "relationships": {
     "vaultCipher": {
-      "data": [
-        {
-          "_id": "123abc",
-          "_type": "com.bitwarden.ciphers",
-          "_protocol": "bitwarden"
-        }
-      ]
+      "data": {
+        "_id": "123abc",
+        "_type": "com.bitwarden.ciphers",
+        "_protocol": "bitwarden"
+      }
     }
   }
 }


### PR DESCRIPTION
In https://github.com/cozy/cozy-doctypes/pull/119 we wrongly introduced
an array in io.cozy.account's vaultCipher relationships. This could let
somebody think that an account can have a relationship to multiple
ciphers, which is not the case. Since an account can only be linked to
one cipher, the value of `relationships.vaultCipher.data` should be an
object.