### PR TITLE
docs: io.cozy.files thumbnails links validity

### DIFF
--- a/docs/io.cozy.files.md
+++ b/docs/io.cozy.files.md
@@ -54,7 +54,7 @@ The attributes of a file are:
 It also has a relationship with its `parent` in the JSON-API representation.
 
 For an `image`, there are 3 links to thumbnails: `small`, `medium`, and `large`. 
-Theses thumbnails' links are valid for 10 minutes. 
+These thumbnail links are valid for 10 minutes. After that, links will return a 400 Bad Request response code.
 
 ### References
 

--- a/docs/io.cozy.files.md
+++ b/docs/io.cozy.files.md
@@ -53,7 +53,8 @@ The attributes of a file are:
 
 It also has a relationship with its `parent` in the JSON-API representation.
 
-For an `image`, there are 3 links to thumbnails: `small`, `medium`, and `large`.
+For an `image`, there are 3 links to thumbnails: `small`, `medium`, and `large`. 
+Theses thumbnails' links are valid for 10 minutes. 
 
 ### References
 


### PR DESCRIPTION
Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [x] in the `Readme.md` index page
- [x] in the `toc.yml` page
