### PR TITLE
feat: Store informations about where the file comes from

### DIFF
--- a/docs/io.cozy.files_metadata.md
+++ b/docs/io.cozy.files_metadata.md
@@ -19,6 +19,9 @@ For pictures files, like `jpg`, `png`, `gif`...
     - `created_at`: {date}: date of creation of the tag
     - `x`: {float}: x coordinate in the photo where the person is
     - `y`: {float}: y coordinate in the photo where the person is
+- `from`: {object}: describe where this document comes from 
+    - `device_id`: {string} an identifier of the device where the file comes from (can be the device's name, an UDID or else)
+    - `original_id`: {string} an identifier of the file on the device 
 
 
 ## Administrative documents


### PR DESCRIPTION
Afin d'améliorer la synchronisation mobile des images, nous avons besoin de stocker quelques informations relatives au fichier présent sur le téléphone.

En effet, en stockant l'id du téléphone et l'id "local" de la photo on pourra : 
- ne pas re-synchroniser une image même si on l'a bougée de place sur le téléphone 
- récupérer toute la liste des photos synchronisées pour un device (et améliorer le cas déco / reco) 
- pouvoir gérer plusieurs répertoires de synchro (si on a plusieurs téléphones ou qu'on a changé de téléphone) 
- etc

