### PR TITLE
docs: Remove deprecated mention for account_type

### DIFF
--- a/docs/io.cozy.accounts.md
+++ b/docs/io.cozy.accounts.md
@@ -8,7 +8,7 @@ Accounts can be managed in [Cozy-Home](http://github.com/cozy/cozy-home/) (via [
 
 `io.cozy.accounts` attributes are:
 
-- `account_type` (_deprecated_) : {string} Slug of the konnector the account is related to.
+- `account_type`: {string} Slug of the konnector the account is related to. Note this could be a [relationship](https://github.com/cozy/cozy-doctypes/#relationships) to the konnector manifest, but we keep this field for historical reasons.
 - `auth`: {object} Contains authentification data, typically a couple with `login`/`password`. It could also contain an attribute `token` for OAuth konnectors.
 - `data`: {object} Additional custom data.
 - `label`: {string} Label given by user.


### PR DESCRIPTION
As we rely on `account_type` to know which konnector is linked to an account, there is no reason yet to mark it as deprecated, even though we expect to use a relationship in the future.