### PR TITLE
docs: fix typo in contact doctype

### DIFF
--- a/docs/io.cozy.contacts.md
+++ b/docs/io.cozy.contacts.md
@@ -30,7 +30,7 @@ The `io.cozy.contacts` doctype is loosely based on the [vCard RFC](https://tools
     - `region?`: {string}
     - `postcode?`: {string}
     - `country?`: {string}
-    - `type?`: {string} Programmatic type of email (`"work"`, `"home"`, `"other"`)
+    - `type?`: {string} Programmatic type of address (`"work"`, `"home"`, `"other"`)
     - `primary?`: {boolean} Indicates a preferred-use address
     - `label?`: {string}
     - `formattedAddress?`: {string} Unstructured version of the address


### PR DESCRIPTION
fix typo in contact doctype

Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [ ] in the `Readme.md` index page
- [ ] in the `toc.yml` page
