### PR TITLE
docs: Add the io.cozy.files.settings doctype

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ for another doctype, feel free to open a PR with the description and role of you
 - [io.cozy.notifications](io.cozy.notifications.md): Notifications made by the apps (Email or Push notifications)
 - [io.cozy.permissions](io.cozy.permissions.md): Permissions of the instance
 - [io.cozy.photos](io.cozy.photos.md): Photos
+  - [io.cozy.photos.settings](io.cozy.photos.md#iocozyphotossettings): Photos settings
 - [io.cozy.procedures](io.cozy.procedures.md): Administrative procedures
 - [io.cozy.docrules](io.cozy.docrules.md): Rules to retrieve documents
 - [io.cozy.sessions.logins](io.cozy.sessions.logins.md): Sessions logins entry

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ for another doctype, feel free to open a PR with the description and role of you
   - [io.cozy.contacts.accounts](io.cozy.contacts.md#iocozycontactsaccounts): Vendors account
 - [io.cozy.files](io.cozy.files.md): Files
   - [Files_metadatas](io.cozy.files_metadata.md): Metadatas about files
+  - [io.cozy.files.settings](io.cozy.files.md#iocozyfilessettings): Files settings
 - [io.cozy.konnectors](io.cozy.konnectors.md): Connectors installed in the cozy
 - [io.cozy.identities](io.cozy.identities.md): Instance owner identities
 - [io.cozy.notes](io.cozy.notes.md): Notes with collaborative edition

--- a/docs/io.cozy.files.md
+++ b/docs/io.cozy.files.md
@@ -284,3 +284,9 @@ fields), and a relationship to the versioned file.
   }
 }
 ```
+
+## `io.cozy.files.settings`
+
+This doctype is used to store settings for files. It is currenly only used for the qualification migration service.
+
+- lastProcessedFileDate: {string} the date of the last processed file. It is used to know from where the query should be starting on an index sorted by date.

--- a/docs/io.cozy.files.md
+++ b/docs/io.cozy.files.md
@@ -289,4 +289,4 @@ fields), and a relationship to the versioned file.
 
 This doctype is used to store settings for files. It is currenly only used for the qualification migration service.
 
-- lastProcessedFileDate: {string} the date of the last processed file. It is used to know from where the query should be starting on an index sorted by date.
+- lastProcessedFileDate: {string} the `cozyMetadata.updatedAt` date of the last processed file. It is used to know from where the query should be starting on an index sorted by date.


### PR DESCRIPTION
This doctype is introduced in the qualification migration service in Drive https://github.com/cozy/cozy-drive/pull/2152