### PR TITLE
add specific doctype for Grand Lyon - request backend grand lyon

### DIFF
--- a/org.mps.store/request
+++ b/org.mps.store/request
@@ -1,0 +1,5 @@
+POST https://pilote-agent-rec.grandlyon.com/api/beneficiaire/create
+Authorization: Bearer {{secret_token}}
+Content-Type: application/json
+
+{{data}}


### PR DESCRIPTION
Add specific doctype for Grand Lyon utilisation. 
- compose of API url of GL backend 
- user secret_token Authorization

Note: the domain mentionned is set for recette environment for the moment. 