### PR TITLE
add new remote doctype for Grand lyon

### DIFF
--- a/org.mps.share.rec/request
+++ b/org.mps.share.rec/request
@@ -1,0 +1,4 @@
+POST https://pilote-agent-rec.grandlyon.com/api/auth/token/check
+Content-Type: application/json
+
+{{data}}

--- a/org.mps.share/request
+++ b/org.mps.share/request
@@ -1,0 +1,4 @@
+POST https://pilote-agent.grandlyon.com/api/auth/token/check
+Content-Type: application/json
+
+{{data}}

--- a/org.mps.store.rec/request
+++ b/org.mps.store.rec/request
@@ -1,4 +1,4 @@
-POST https://pilote-agent.grandlyon.com/api/beneficiaire/create
+POST https://pilote-agent-rec.grandlyon.com/api/beneficiaire/create
 Authorization: Bearer {{secret_token}}
 Content-Type: application/json
 

--- a/org.mps.store/request
+++ b/org.mps.store/request
@@ -1,0 +1,5 @@
+POST https://pilote-agent-rec.grandlyon.com/api/beneficiaire/create
+Authorization: Bearer {{secret_token}}
+Content-Type: application/json
+
+{{data}}


### PR DESCRIPTION
- Adding org.mps.share/request used into Pilote service in order to check one token received from Grand Lyon backend
* Post on PROD Url. Do i need to push rec url for the moment ? 

- No change on org.mps.store/request