### PR TITLE
feat: Add remote doctype for BI maif sandbox

### DIFF
--- a/com.budgetinsight.maifsandbox.api/request
+++ b/com.budgetinsight.maifsandbox.api/request
@@ -1,0 +1,9 @@
+POST https://maif-sandbox.biapi.pro/2.0/auth/token
+Content-Type: application/json
+
+{
+  "client_id": "{{secret_clientId}}",
+  "client_secret": "{{secret_clientSecret}}",
+  "grant_type": "{{secret_grantType}}",
+  "scope": "{{secret_scope}}"
+}


### PR DESCRIPTION
Allows to get a token from BI (with the secrets of the stack).

It will be used for the API PAY (transfer) via Banks App.
