### PR TITLE
docs: Add Bitwarden sharing related doctypes

### DIFF
--- a/docs/com.bitwarden.ciphers.md
+++ b/docs/com.bitwarden.ciphers.md
@@ -21,6 +21,8 @@ The `com.bitwarden.ciphers` doctype is used to store secret things for the
 - `login`: {object} - an object only used when type is 1 (see below)
 - `data`: {object} - a map of encrypted properties on the cipher
 - `fields`: {array} - a list of objects, with `type`, `name`, and `value` (encrypted)
+- `organization_id`: {uuid} - the identifier of a [bitwarden organization](./com.bitwarden.organizations.md)
+- `collection_id`: {uuid} - the identifier of the collection (see [bitwarden organization](./com.bitwarden.organizations.md))
 - `cozyMetadata`: {object} - the [cozyMetadata](README.md#document-metadata)
 - `deletedDate`: {string} - the [soft deletion date](https://docs.cozy.io/en/cozy-stack/bitwarden/#put-bitwardenapiciphersiddelete) of the cipher. It is used to trash ciphers.
 
@@ -53,6 +55,8 @@ When the cipher has type 1 (login), the `login` is an object with these fields:
     "password": "2.L+41A7ch4GypwrIFXG5vkA==|S3eFnoNtk1IpsT4gcfcNrw==|lqdBTpSHKqTJtgBBXBXqm2K249AF1gZMec4cFf5gqR0="
   },
   "fields": null,
+  "organization_id": "8869e3ee461551cc2bc4d5d9a107dbf9",
+  "collection_id": "8869e3ee461551cc2bc4d5d9a107d0c1",
   "cozyMetadata": {
     "doctypeVersion": "1",
     "metadataVersion": 1,

--- a/docs/com.bitwarden.contacts.md
+++ b/docs/com.bitwarden.contacts.md
@@ -1,0 +1,34 @@
+[Table of contents](README.md#table-of-contents)
+
+# Bitwarden contacts
+
+The `com.bitwarden.contacts` doctype is used to share
+[organizations](./com.bitwarden.organizations.md) with other users.
+
+A `com.bitwarden.contacts` may be linked to a [Cozy contacts](./io.cozy.contacts.md)
+by using the `email` attribute.
+
+## Attributes
+
+- `email`: {string} - the email of the contact
+- `public_key`: {string} - the public key of the contact
+- `confirmed`: {bool} - true if the contact's fingerprint phrase has been verified and confirmed by the user
+- `cozyMetadata`: {object} - the [cozyMetadata](README.md#document-metadata)
+
+## Example
+
+```json
+{
+  "_id": "49a6e10fc3718829c4dac13a9e015597",
+  "_rev": "1-49847ab10b103b2e084b0231e339ddce",
+  "email": "me@bob.cozy.localhost",
+  "public_key": "4.MbW...QVdA==",
+  "confirmed": true,
+  "cozyMetadata": {
+    "doctypeVersion": "1",
+    "metadataVersion": 1,
+    "createdAt": "2021-08-30T17:41:49.991184+02:00",
+    "updatedAt": "2021-08-30T17:41:49.991184+02:00"
+  }
+}
+```

--- a/docs/com.bitwarden.organizations.md
+++ b/docs/com.bitwarden.organizations.md
@@ -1,0 +1,79 @@
+[Table of contents](README.md#table-of-contents)
+
+# Bitwarden organization
+
+The `com.bitwarden.organization` doctype is used to group
+[ciphers](./com.bitwarden.ciphers.md) in a single unit and/or to share them with
+other [bitwarden contacts](./com.bitwarden.contacts.md).
+
+## Attributes
+
+- `name`: {string} - the name of the organization
+- `members`: {object} - the members of the organization (see below)
+- `defaultCollection`: {object} - the collection of the organization (see below)
+- `cozyMetadata`: {object} - the [cozyMetadata](README.md#document-metadata)
+
+## Members
+
+An organization can be shared with a list of members.
+
+- `email`: {string} - the email of the member from [bitwarden contacts](./com.bitwarden.contacts.md)
+- `key`: {string} - the organization's key encrypted with the public key of the member from [bitwarden contacts](./com.bitwarden.contacts.md)
+- `name`: {string} - the name of the member
+- `owner`: {bool} - true if the member owns the organization
+- `status`: {int} - the status of the member (`0` = `invited`, `1` = `accepted`, `2` = `confirmed`)
+- `user_id`: {string} - the id of the member from [bitwarden contacts](./com.bitwarden.contacts.md)
+
+Note that the `name` and `key` attributes may be missing if the member status is still `invited` as those data are sent only when he accepts the first [Cozy sharing](./io.cozy.sharings.md) from organization's owner.
+
+## Collection
+
+A collection is a virtual container for [ciphers](./com.bitwarden.ciphers.md).
+
+A [ciphers](./com.bitwarden.ciphers.md) can live alone or included in a collection. Any collection is linked to an organization.
+
+By construction the Bitwarden protocol allows an organization to contain one or more collections.
+
+But at Cozy we defined that an organization must contain exactly one collection. So there is no need seperate those entities, and so there is no dedicated doctype for a collection.
+
+The collection entity exists to comply with the Bitwarden protocol.
+
+- `_id`: {string} - the id of the collection
+- `name`: {string} - the name of the collection, encrypted as a cipherString with AES
+
+## Example
+
+```json
+{
+  "_id": "8869e3ee461551cc2bc4d5d9a107dbf9",
+  "_rev": "2-1926d7ef135d622721fc2e44519399cf",
+  "name": "test",
+  "members": {
+    "alice.cozy.localhost:8080": {
+      "email": "me@alice.cozy.localhost",
+      "key": "4.Xzx...+w3Q==",
+      "name": "Alice",
+      "owner": true,
+      "status": 2,
+      "user_id": "49a6e10fc3718829c4dac13a9e0036b0"
+    },
+    "bob.cozy.localhost:8080": {
+      "email": "me@bob.cozy.localhost",
+      "key": "4.MbW...QVdA==",
+      "name": "Bob",
+      "status": 2,
+      "user_id": "49a6e10fc3718829c4dac13a9e015597"
+    }
+  },
+  "defaultCollection": {
+    "_id": "8869e3ee461551cc2bc4d5d9a107d0c1",
+    "name": "2.zedwpSJJACs2y+QSzxwqNA==|VB6iWyyRM++AFH7QjsJ/iw==|INFs55T//Ge1CIpyHh1tritNhaxfXGHDgb5yLyzqjjk="
+  },
+  "cozyMetadata": {
+    "doctypeVersion": "1",
+    "metadataVersion": 1,
+    "createdAt": "2021-08-30T17:29:31.431874+02:00",
+    "updatedAt": "2021-08-30T17:29:31.431874+02:00"
+  }
+}
+```

--- a/toc.yml
+++ b/toc.yml
@@ -34,4 +34,6 @@
 - Terms: ./docs/io.cozy.terms.md
 - Bitwarden ciphers: ./docs/com.bitwarden.ciphers.md
 - Bitwarden folders: ./docs/com.bitwarden.folders.md
+- Bitwarden organizations: ./docs/com.bitwarden.organizations.md
+- Bitwarden contacts: ./docs/com.bitwarden.contacts.md
 - Bets Unibet: ./docs/com.unibet.bets.md


### PR DESCRIPTION
Those doctypes are used to manage organization and share ciphers with
other users :
- com.bitwarden.organizations
- com.bitwarden.contacts

Also `com.bitwarden.ciphers` has been completed with organization
related attributes

Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [x] in the `Readme.md` index page
- [x] in the `toc.yml` page
