### PR TITLE
feat: Add io.cozy.files.encryption doctype

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ for another doctype, feel free to open a PR with the description and role of you
 - [io.cozy.files](io.cozy.files.md): Files
   - [Files_metadatas](io.cozy.files_metadata.md): Metadatas about files
   - [io.cozy.files.settings](io.cozy.files.md#iocozyfilessettings): Files settings
+  - [io.cozy.files.encryption](io.cozy.files.md#iocozyfilesencryption): Files encryption
 - [io.cozy.konnectors](io.cozy.konnectors.md): Connectors installed in the cozy
 - [io.cozy.identities](io.cozy.identities.md): Instance owner identities
 - [io.cozy.notes](io.cozy.notes.md): Notes with collaborative edition

--- a/docs/io.cozy.files.md
+++ b/docs/io.cozy.files.md
@@ -297,3 +297,12 @@ fields), and a relationship to the versioned file.
 This doctype is used to store settings for files. It is currenly only used for the qualification migration service.
 
 - lastProcessedFileDate: {string} the `cozyMetadata.updatedAt` date of the last processed file. It is used to know from where the query should be starting on an index sorted by date.
+
+## `io.cozy.files.encryption`
+
+This doctype is used to store encryption keys for directories.
+The encryption keys are stored encrypted in the same way than bitwarden's [ciphers](https://docs.cozy.io/cozy-doctypes/com.bitwarden.ciphers.html), and are used to encrypt/decrypt files' binary inside the directory.
+
+
+- `_id`: {string} refers to its directory id: `io.cozy.files/<dirID>`
+- `key`: {string} the encrypted key, used to encrypt/decrypt files inside the directory.


### PR DESCRIPTION
This doctype will be useful for incoming client-side encryption in Drive

