### PR TITLE
docs: adding link for generic model

### DIFF
--- a/docs/io.cozy.files_metadata.md
+++ b/docs/io.cozy.files_metadata.md
@@ -2,7 +2,7 @@
 
 ## Generic metadata
 
-For generic metadata like `createdAt` or `updatedAt`, please follow the [cozy-doctypes doc](https://github.com/cozy/cozy-doctypes/#generic-model) about generic model
+For generic metadata like `createdAt` or `updatedAt`, please follow the [cozy-doctypes doc](./#generic-model) about generic model
 
 ## Image files
 
@@ -116,7 +116,7 @@ expected in every cases.
 - `datetime` : {date} Equals to the date attribute specified by `datetimeLabel`.
 - `datetimeLabel` : {string} specify which attribute is used as `datetime`, e.g.
   `issueDate` or `startDate`.
-- `issueDate` : {date} issue date of the document emit by the vendor.
+- `issueDate` : {date} issue date of the document emitted by the vendor.
 - `startDate` : {date} first day of a period, e.g. for a contract.
 - `endDate` : {date} last day of a period, e.g. for a contract.
 - `expirationDate` : {date} last day of validity, e.g. for an identity document.

--- a/docs/io.cozy.files_metadata.md
+++ b/docs/io.cozy.files_metadata.md
@@ -1,5 +1,9 @@
 # Metadata on `io.cozy.files` documents
 
+## Generic metadata
+
+For generic metadata like `createdAt` or `updatedAt`, please follow the [cozy-doctypes doc](https://github.com/cozy/cozy-doctypes/#generic-model) about generic model
+
 ## Image files
 
 For pictures files, like `jpg`, `png`, `gif`...
@@ -112,7 +116,7 @@ expected in every cases.
 - `datetime` : {date} Equals to the date attribute specified by `datetimeLabel`.
 - `datetimeLabel` : {string} specify which attribute is used as `datetime`, e.g.
   `issueDate` or `startDate`.
-- `issueDate` : {date} issue date of the document.
+- `issueDate` : {date} issue date of the document emit by the vendor.
 - `startDate` : {date} first day of a period, e.g. for a contract.
 - `endDate` : {date} last day of a period, e.g. for a contract.
 - `expirationDate` : {date} last day of validity, e.g. for an identity document.


### PR DESCRIPTION
Adding link to send user to the generic model examples & documentation

Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [ ] in the `Readme.md` index page
- [ ] in the `toc.yml` page
