### PR TITLE
feat: Add client-dedicated DACC server remote doctype

### DIFF
--- a/eu.mycozy.dacc/request
+++ b/eu.mycozy.dacc/request
@@ -1,0 +1,5 @@
+POST https://dacc.mycozy.eu/measure
+Authorization: Bearer {{secret_token}}
+Content-Type: application/json
+
+{{data}}


### PR DESCRIPTION

No documentation for this remote doctype as there is no documentation for the other dacc remote doctypes.
