### PR TITLE
docs: Add link for GeoJSON example

### DIFF
--- a/docs/io.cozy.timeseries.md
+++ b/docs/io.cozy.timeseries.md
@@ -16,7 +16,7 @@ Any type of time series must follow the same common structure:
 
 ## `io.cozy.timeseries.geojson`
 
-These time series follow the [GeoJSON](https://geojson.org/) format. 
+These time series follow the [GeoJSON](https://geojson.org/) format. See [here](https://github.com/cozy/coachCO2#timeseries-models-and-nomenclature) for a complete example of this doctype.
 
 ###  Example
 


### PR DESCRIPTION
The CoachCO2 README describes the GeoJSON received from Tracemob. We add a link as a possible (but possibly not unique) geoJSON example. 