### PR TITLE
feat: Add cc.cozycloud.errors remote doctype

### DIFF
--- a/cc.cozycloud.errors/request
+++ b/cc.cozycloud.errors/request
@@ -1,0 +1,4 @@
+POST https://errors.cozycloud.cc/api/{{project}}/store/
+X-Sentry-Auth: Sentry sentry_version={{sentry_version}}, sentry_client={{sentry_client}}, sentry_key={{sentry_key}}
+
+{{data}}


### PR DESCRIPTION
Nous avons migré de serveur sentry. Il est nécessaire d'ajouter un remote doctype pour la nouvelle url