### PR TITLE
feat: Use path as parameter in dacc remote-doctypes

### DIFF
--- a/cc.cozycloud.dacc.dev/request
+++ b/cc.cozycloud.dacc.dev/request
@@ -1,4 +1,4 @@
-POST https://dacc-dev.cozycloud.cc/measure
+POST https://dacc-dev.cozycloud.cc/{{path}}
 Authorization: Bearer {{secret_token}}
 Content-Type: application/json
 

--- a/cc.cozycloud.dacc/request
+++ b/cc.cozycloud.dacc/request
@@ -1,4 +1,4 @@
-POST https://dacc.cozycloud.cc/measure
+POST https://dacc.cozycloud.cc/{{path}}
 Authorization: Bearer {{secret_token}}
 Content-Type: application/json
 

--- a/eu.mycozy.dacc/request
+++ b/eu.mycozy.dacc/request
@@ -1,4 +1,4 @@
-POST https://dacc.mycozy.eu/measure
+POST https://dacc.mycozy.eu/{{path}}
 Authorization: Bearer {{secret_token}}
 Content-Type: application/json
 


### PR DESCRIPTION
This will be useful to either send measures to the DACC through
`/measure` or to receive results through `/aggregate`

