### PR TITLE
feat: Add new DACC remote-doctype

### DIFF
--- a/cc.cozycloud.dacc.dev_v2/request
+++ b/cc.cozycloud.dacc.dev_v2/request
@@ -1,0 +1,5 @@
+POST https://dacc-dev.cozycloud.cc/{{path}}
+Authorization: Bearer {{secret_token}}
+Content-Type: application/json
+
+{{data}}

--- a/cc.cozycloud.dacc_v2/request
+++ b/cc.cozycloud.dacc_v2/request
@@ -1,0 +1,5 @@
+POST https://dacc.cozycloud.cc/{{path}}
+Authorization: Bearer {{secret_token}}
+Content-Type: application/json
+
+{{data}}

--- a/eu.mycozy.dacc_v2/request
+++ b/eu.mycozy.dacc_v2/request
@@ -1,0 +1,5 @@
+POST https://dacc.mycozy.eu/{{path}}
+Authorization: Bearer {{secret_token}}
+Content-Type: application/json
+
+{{data}}


### PR DESCRIPTION
This is useful to be able to query any DACC path, without breaking the
existing services using `cc.cozycloud.dacc`, `cc.cozycloud.dacc.dev`, `eu.mycozy.dacc`.
Eventually, those remote-doctypes will be removed

Note this discards https://github.com/cozy/cozy-doctypes/pull/201/files
