### PR TITLE
docs: Add full list of where we need to add the doctype

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,3 +2,8 @@ Thanks for contributing to this documentation. If you added a doctype, please be
 
 - [ ] in the `Readme.md` index page
 - [ ] in the `toc.yml` page
+- [ ] https://github.com/cozy/cozy-store/blob/master/src/locales/en.json
+- [ ] https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json
+- [ ] https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions
+- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po
+- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/styles/cirrus.css


### PR DESCRIPTION
Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [ ] in the `Readme.md` index page
- [ ] in the `toc.yml` page
