### PR TITLE
feat: add client_side attribute to manifests

### DIFF
--- a/docs/io.cozy.konnectors.md
+++ b/docs/io.cozy.konnectors.md
@@ -20,7 +20,8 @@ Field              | Description
 -------------------|---------------------------------------------------------------------------------------------------
 `aggregator`       | Object containing aggregator data. Typically `{ accountId: 'aggregator-service' }`.
 `categories`       | array of categories for your apps (see authorized categories), it will be `['others']` by default if empty
-`clientSide`       | Boolean to specify if the konnector should be run on the client or not
+`clientSide`       | Boolean to specify if the konnector should be run on the client or not (deprecated)
+`client_side`      | Boolean to specify if the konnector should be run on the client or not
 `data_types`       | _(konnector specific)_ Array of the data type the konnector will manage
 `developer`        | `name` and `url` for the developer
 `editor`           | the editor's name to display on the cozy-bar (__REQUIRED__)


### PR DESCRIPTION
In replacement of `clientSide` since snake case is the norm.
clientSide is deprecated

See https://github.com/cozy/cozy-doctypes/pull/221#issuecomment-1401530735

Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [ ] in the `Readme.md` index page
- [ ] in the `toc.yml` page
- [ ] https://github.com/cozy/cozy-store/blob/master/src/locales/en.json
- [ ] https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json
- [ ] https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions
- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po
- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/styles/cirrus.css
