### PR TITLE
docs: Add default redirection in instance settings

### DIFF
--- a/docs/io.cozy.settings.md
+++ b/docs/io.cozy.settings.md
@@ -12,6 +12,7 @@ is the stack instance-related settings.
 - `tz`: {string} Timezone of the instance (ex: `Europe/Paris`)
 - `email`: {string} Email of the instance
 - `public_name`: {string} Public displayed name of the instance
+- `default_redirection`: {string} Redirect to an app after login (ex: `drive/#/folder`)
 
 There is also a document with the stuff related to authentication and Bitwarden:
 


### PR DESCRIPTION
I will also add in a next PR the 'io.cozy.home.settings' doctype.