### PR TITLE
fix: Replace cozy-collect by cozy-home

### DIFF
--- a/docs/io.cozy.konnectors.md
+++ b/docs/io.cozy.konnectors.md
@@ -8,7 +8,7 @@ The `io.cozy.konnectors` doctype is used to store installed konnectors.
 
 When installing a konnector, the Cozy stack creates a new `io.cozy.konnector` document from the fields in the `manifest.konnector`.
 
-`io.cozy.konnectors` are used by [Cozy-Store](http://github.com/cozy/cozy-store/) to install and uninstall konnectors, and by [Cozy-Collect](http://github.com/cozy/cozy-collect/) to manage [accounts](io.cozy.accounts.md) for konnectors
+`io.cozy.konnectors` are used by [Cozy-Store](http://github.com/cozy/cozy-store/) to install and uninstall konnectors, and by [Cozy-Home](http://github.com/cozy/cozy-home/) to manage [accounts](io.cozy.accounts.md) for konnectors
 
 ## Attributes
 

--- a/docs/io.cozy.triggers.md
+++ b/docs/io.cozy.triggers.md
@@ -4,7 +4,7 @@
 
 `io.cozy.triggers` documents are used by the stack to configure [how and when a job should be runned](https://docs.cozy.io/en/cozy-stack/jobs/).
 
-This is a special doctype which can only be created from an app. We are using it in [Cozy-Collect](http://github.com/cozy/cozy-collect/) to manage konnectors scheduling.
+This is a special doctype which can only be created from an app. We are using it in [Cozy-Home](http://github.com/cozy/cozy-home/) to manage konnectors scheduling.
 
 ## Attributes
 


### PR DESCRIPTION
As [Cozy-Collect](http://github.com/cozy/cozy-collect/) redirects to [Cozy-Home](http://github.com/cozy/cozy-home/), I've changed the naming for greater consistency