### PR TITLE
docs: Add cozy-client when we add a new doctype

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,5 +5,6 @@ Thanks for contributing to this documentation. If you added a doctype, please be
 - [ ] https://github.com/cozy/cozy-store/blob/master/src/locales/en.json
 - [ ] https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json
 - [ ] https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions
+- [ ] https://github.com/cozy/cozy-client/tree/master/packages/cozy-client/src/models/doctypes/locales
 - [ ] https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po
 - [ ] https://github.com/cozy/cozy-stack/blob/master/assets/styles/cirrus.css


### PR DESCRIPTION
We need to update cozy-client when we add a new doctype