### PR TITLE
[SCR-236] docs: Add 'taxNumber' new metadata attribute

### DIFF
--- a/docs/io.cozy.files_metadata.md
+++ b/docs/io.cozy.files_metadata.md
@@ -135,6 +135,7 @@ expected in every cases.
 - `noticePeriod` : {string} number of days before expiration alert.
 - `contractType` : {string} type of employment contract.
 - `refTaxIncome` : {string} reference tax income.
+- `taxNumber` : {string} fiscal reference number.
 - `invoiceNumber` : {string} invoice number.
 - `number` : {string} Relative number e.g. iban number for an iban document.
 - `contractReference` : {string} reference of the related contract.
@@ -182,7 +183,8 @@ to be added to a document.
 - `datetimeLabel` : {string} `'issueDate'`
 - `contentAuthor` : {string}
 - `issueDate` : {date} Issue date of the document
-- `refTaxIncom` : {string} reference tax income.
+- `refTaxIncome` : {string} reference tax income.
+- `taxNumber` : {string} fiscal reference number.
 
 #### Tax Returns
 
@@ -351,7 +353,9 @@ to be added to a document.
   "datetime": "2019-05-10",
   "datetimeLabel": "issueDate",
   "contentAuthor": "impots.gouv",
-  "issueDate": "2019-05-10"
+  "issueDate": "2019-05-10",
+  "taxNumber": "1234567891011",
+  "refTaxIncome" : "12345"
 },
 "cozyMetadata": {
   ...


### PR DESCRIPTION
Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [ ] in the `Readme.md` index page
- [ ] in the `toc.yml` page
- [ ] https://github.com/cozy/cozy-store/blob/master/src/locales/en.json
- [ ] https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json
- [ ] https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions
- [ ] https://github.com/cozy/cozy-client/tree/master/packages/cozy-client/src/models/doctypes/locales
- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po
- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/styles/cirrus.css

This PR adds a new metadata attribute named `taxNumber`. It is the fiscal reference number scraped from the taxes pdfs