### PR TITLE
chore: remove ecolyo dju v2

### DIFF
--- a/org.ecolyo.dju_v2/request
+++ b/org.ecolyo.dju_v2/request
@@ -1,2 +1,0 @@
-GET https://download.data.grandlyon.com/ws/timeseries/meteofrance.bron_mesure/all.json?maxfeatures=-1&start=1&horodate__gte={{startDate}}&horodate__lt={{endDate}}
-Authorization: Basic {{secret_token}}


### PR DESCRIPTION
This PR removes org.ecolyo.dju_v2 as we are now using org.ecolyo.dju_v3