### PR TITLE
feat: Addition of calendar and grades timeseries doctype

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ for another doctype, feel free to open a PR with the description and role of you
   - [io.cozy.bank.groups](io.cozy.bank.md#iocozybankgroups): Group of bank accounts
   - [io.cozy.bank.recipients](io.cozy.bank.md#iocozybankrecipients): Recipients for transfert
 - [io.cozy.bills](io.cozy.bills.md): Bills
+- [io.cozy.calendar](io.cozy.calendar.md): Calendar
 - [io.cozy.coachco2.settings](io.cozy.coachco2.md): CoachCO2 application settings
 - [io.cozy.contacts](io.cozy.contacts.md): Contacts
   - [io.cozy.contacts.groups](io.cozy.contacts.md#iocozycontactsgroups): Contacts groups
@@ -54,6 +55,7 @@ for another doctype, feel free to open a PR with the description and role of you
 - [io.cozy.tags](io.cozy.tags.md): Tags
 - [io.cozy.timeseries](io.cozy.timeseries.md): Time Series
   - [io.cozy.timeseries.geojson](io.cozy.timeseries.md#iocozytimeseriesgeojson): GeoJSON time series
+  - [io.cozy.timeseries.grades](io.cozy.timeseries.md#iocozytimeseriesgrades): Grades time series
 - [io.cozy.todos](io.cozy.todos.md): Todos
   - [io.cozy.todos.list](io.cozy.todos.md#iocozytodoslist): Todos list
   - [io.cozy.todos.item](io.cozy.todos.md#iocozytodositem): Todos item

--- a/docs/io.cozy.calendar.md
+++ b/docs/io.cozy.calendar.md
@@ -11,7 +11,7 @@ The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://d
 - `label?` : {string}
 - `description?` : {string}
 - `location?` : {string}
-- `organiser?` : {string}
+- `organizer?` : {string}
 - `status?` : {string} `CONFIRMED|CANCELLED`
 - `attendee?` : {array} Array of string with event attendees
 

--- a/docs/io.cozy.calendar.md
+++ b/docs/io.cozy.calendar.md
@@ -6,21 +6,21 @@
 
 The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://datatracker.ietf.org/doc/html/rfc5545), in that some of the attributes have been renamed for clarity. The attributes with a `?` are optional.
 
-- `start?` : {date} (example: `"1959-05-15"`)
-- `end?` : {date} (example: `"1959-05-15"`)
+- `start?` : {date}
+- `end?` : {date}
 - `label?` : {string}
 - `description?` : {string}
 - `location?` : {string}
 - `organiser?` : {string}
 - `status?` : {string} `CONFIRMED|CANCELLED`
-- `attendee?` : {object} Array of string with event attendees
+- `attendee?` : {array} Array of string with event attendees
 
 ### Example
 ```json
 {
   "_id": "62e5d66d6e11d19992b7efce794263f0",
-  "start": "20170422T010000",
-  "end": "20170422T010000",
+  "start": "2018-01-02T20:38:04Z",
+  "end": "2018-01-02T20:38:04Z",
   "label": "history-geography"
   "location": "B209 BIS",
   "organizer": "Mme. Dubois",
@@ -33,22 +33,22 @@ The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://d
 ## `io.cozy.calendar.events`
 Used to save calendar event data, to be shown in a timetable or to save past time related activities.
 
-- `start` : {date} (example: `"1959-05-15"`)
-- `end` : {date} (example: `"1959-05-15"`)
+- `start` : {date}
+- `end` : {date}
 - `label` : {string}
 
 ## `io.cozy.calendar.todos`
 Used to save and retrieve to-do items
 
-- `dueDate` : {date} (example: `"1959-05-15"`)
+- `dueDate` : {date}
 - `summary` : {string}
 - `completed` : {boolean}
 
 ## `io.cozy.calendar.presence`
 Used to  track attendance and presence related events
 
-- `start` : {date} (example: `"1959-05-15"`)
-- `end` : {date} (example: `"1959-05-15"`)
+- `start` : {date}
+- `end` : {date}
 - `label?` : {string}
 - `justified?` : {boolean}
 - `type` : {string} `delay | absence | observation`

--- a/docs/io.cozy.calendar.md
+++ b/docs/io.cozy.calendar.md
@@ -6,14 +6,17 @@
 
 The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://datatracker.ietf.org/doc/html/rfc5545), in that some of the attributes have been renamed for clarity. The attributes with a `?` are optional.
 
-- `start?` : {date}
-- `end?` : {date}
-- `label?` : {string}
-- `description?` : {string}
-- `location?` : {string}
-- `organizer?` : {string}
-- `status?` : {string} `CONFIRMED|CANCELLED`
-- `attendee?` : {array} Array of string with event attendees
+- `start?` : {date} [Start of event](https://www.kanzaki.com/docs/ical/dtstart.html)
+- `end?` : {date} [End of event](https://www.kanzaki.com/docs/ical/dtend.html)
+- `timezone?` : {sting} [TZID identifier](https://www.kanzaki.com/docs/ical/tzid.html) for a specific time zone
+- `frequency?` : {number} [Frequency of recurrence](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html)
+- `until?` : {date} Date of [end of reccurence](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) specified with frequency
+- `label?` : {string} [Event description](https://www.kanzaki.com/docs/ical/description.html)
+- `description?` : {string} [Event comment](https://www.kanzaki.com/docs/ical/comment.html)
+- `location?` : {string} [Event location](https://www.kanzaki.com/docs/ical/location.html)
+- `organizer?` : {string} [Event organizer](https://www.kanzaki.com/docs/ical/organizer.html)
+- `status?` : {string} `CONFIRMED|CANCELLED` [Event status](https://www.kanzaki.com/docs/ical/status.html)
+- `attendee?` : {array} [Array of string with event attendees](https://www.kanzaki.com/docs/ical/attendee.html)
 
 ### Example
 ```json
@@ -21,6 +24,9 @@ The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://d
   "_id": "62e5d66d6e11d19992b7efce794263f0",
   "start": "2018-01-02T20:38:04Z",
   "end": "2018-01-02T20:38:04Z",
+  "timezone": "Europe/Paris",
+  "frequency": "weekly",
+  "until": "2018-01-02T20:38:04Z",
   "label": "history-geography"
   "location": "B209 BIS",
   "organizer": "Mme. Dubois",
@@ -33,22 +39,22 @@ The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://d
 ## `io.cozy.calendar.events`
 Used to save calendar event data, to be shown in a timetable or to save past time related activities.
 
-- `start` : {date}
-- `end` : {date}
-- `label` : {string}
+- `start` : {date} [Start of event](https://www.kanzaki.com/docs/ical/dtstart.html)
+- `end` : {date} [End of event](https://www.kanzaki.com/docs/ical/dtend.html)
+- `label` : {string} [Event description](https://www.kanzaki.com/docs/ical/description.html)
 
 ## `io.cozy.calendar.todos`
 Used to save and retrieve to-do items
 
-- `dueDate` : {date}
-- `summary` : {string}
-- `completed` : {boolean}
+- `dueDate` : {date} [Todo due date](https://www.kanzaki.com/docs/ical/due.html)
+- `summary` : {string} [Todo summary](https://www.kanzaki.com/docs/ical/summary.html)
+- `completed` : {boolean} [Completion status](https://www.kanzaki.com/docs/ical/completed.html)
 
 ## `io.cozy.calendar.presence`
 Used to  track attendance and presence related events
 
-- `start` : {date}
-- `end` : {date}
-- `label?` : {string}
+- `start` : {date} [Start of event](https://www.kanzaki.com/docs/ical/dtstart.html)
+- `end` : {date} [End of event](https://www.kanzaki.com/docs/ical/dtend.html)
+- `label` : {string} [Event description](https://www.kanzaki.com/docs/ical/description.html)
 - `justified?` : {boolean}
 - `type` : {string} `delay | absence | observation`

--- a/docs/io.cozy.calendar.md
+++ b/docs/io.cozy.calendar.md
@@ -6,17 +6,17 @@
 
 The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://datatracker.ietf.org/doc/html/rfc5545), in that some of the attributes have been renamed for clarity. The attributes with a `?` are optional.
 
-- `start?` : {date} [Start of event](https://www.kanzaki.com/docs/ical/dtstart.html)
-- `end?` : {date} [End of event](https://www.kanzaki.com/docs/ical/dtend.html)
-- `timezone?` : {sting} [TZID identifier](https://www.kanzaki.com/docs/ical/tzid.html) for a specific time zone
+- `start?` : {date} [Start of event](https://icalendar.org/iCalendar-RFC-5545/3-8-2-4-date-time-start.html)
+- `end?` : {date} [End of event](https://icalendar.org/iCalendar-RFC-5545/3-8-2-2-date-time-end.html)
+- `timezone?` : {sting} [TZID identifier](https://icalendar.org/iCalendar-RFC-5545/3-2-19-time-zone-identifier.html) for a specific time zone
 - `frequency?` : {number} [Frequency of recurrence](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html)
 - `until?` : {date} Date of [end of reccurence](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) specified with frequency
-- `label?` : {string} [Event description](https://www.kanzaki.com/docs/ical/description.html)
-- `description?` : {string} [Event comment](https://www.kanzaki.com/docs/ical/comment.html)
-- `location?` : {string} [Event location](https://www.kanzaki.com/docs/ical/location.html)
-- `organizer?` : {string} [Event organizer](https://www.kanzaki.com/docs/ical/organizer.html)
-- `status?` : {string} `CONFIRMED|CANCELLED` [Event status](https://www.kanzaki.com/docs/ical/status.html)
-- `attendee?` : {array} [Array of string with event attendees](https://www.kanzaki.com/docs/ical/attendee.html)
+- `label?` : {string} [Event description](https://icalendar.org/iCalendar-RFC-5545/3-8-1-5-description.html)
+- `description?` : {string} [Event comment](https://icalendar.org/iCalendar-RFC-5545/3-8-1-4-comment.html)
+- `location?` : {string} [Event location](https://icalendar.org/iCalendar-RFC-5545/3-8-1-7-location.html)
+- `organizer?` : {string} [Event organizer](https://icalendar.org/iCalendar-RFC-5545/3-8-4-3-organizer.html)
+- `status?` : {string} `CONFIRMED|CANCELLED` [Event status](https://icalendar.org/iCalendar-RFC-5545/3-8-1-11-status.html)
+- `attendee?` : {array} [Array of string with event attendees](https://icalendar.org/iCalendar-RFC-5545/3-8-4-1-attendee.html)
 
 ### Example
 ```json
@@ -39,22 +39,22 @@ The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://d
 ## `io.cozy.calendar.events`
 Used to save calendar event data, to be shown in a timetable or to save past time related activities.
 
-- `start` : {date} [Start of event](https://www.kanzaki.com/docs/ical/dtstart.html)
-- `end` : {date} [End of event](https://www.kanzaki.com/docs/ical/dtend.html)
-- `label` : {string} [Event description](https://www.kanzaki.com/docs/ical/description.html)
+- `start?` : {date} [Start of event](https://icalendar.org/iCalendar-RFC-5545/3-8-2-4-date-time-start.html)
+- `end?` : {date} [End of event](https://icalendar.org/iCalendar-RFC-5545/3-8-2-2-date-time-end.html)
+- `label?` : {string} [Event description](https://icalendar.org/iCalendar-RFC-5545/3-8-1-5-description.html)
 
 ## `io.cozy.calendar.todos`
 Used to save and retrieve to-do items
 
-- `dueDate` : {date} [Todo due date](https://www.kanzaki.com/docs/ical/due.html)
-- `summary` : {string} [Todo summary](https://www.kanzaki.com/docs/ical/summary.html)
-- `completed` : {boolean} [Completion status](https://www.kanzaki.com/docs/ical/completed.html)
+- `dueDate` : {date} [Todo due date](https://icalendar.org/iCalendar-RFC-5545/3-8-2-3-date-time-due.html)
+- `summary` : {string} [Todo summary](https://icalendar.org/iCalendar-RFC-5545/3-8-1-12-summary.html)
+- `completed` : {boolean} [Completion status](https://icalendar.org/iCalendar-RFC-5545/3-8-2-1-date-time-completed.html)
 
 ## `io.cozy.calendar.presence`
 Used to  track attendance and presence related events
 
-- `start` : {date} [Start of event](https://www.kanzaki.com/docs/ical/dtstart.html)
-- `end` : {date} [End of event](https://www.kanzaki.com/docs/ical/dtend.html)
-- `label` : {string} [Event description](https://www.kanzaki.com/docs/ical/description.html)
+- `start?` : {date} [Start of event](https://icalendar.org/iCalendar-RFC-5545/3-8-2-4-date-time-start.html)
+- `end?` : {date} [End of event](https://icalendar.org/iCalendar-RFC-5545/3-8-2-2-date-time-end.html)
+- `label?` : {string} [Event description](https://icalendar.org/iCalendar-RFC-5545/3-8-1-5-description.html)(https://www.kanzaki.com/docs/ical/description.html)
 - `justified?` : {boolean}
 - `type` : {string} `delay | absence | observation`

--- a/docs/io.cozy.calendar.md
+++ b/docs/io.cozy.calendar.md
@@ -9,8 +9,9 @@ The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://d
 - `start?` : {date} [Start of event](https://icalendar.org/iCalendar-RFC-5545/3-8-2-4-date-time-start.html)
 - `end?` : {date} [End of event](https://icalendar.org/iCalendar-RFC-5545/3-8-2-2-date-time-end.html)
 - `timezone?` : {sting} [TZID identifier](https://icalendar.org/iCalendar-RFC-5545/3-2-19-time-zone-identifier.html) for a specific time zone
-- `frequency?` : {number} [Frequency of recurrence](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html)
-- `until?` : {date} Date of [end of reccurence](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) specified with frequency
+- `rrule` : {dict} [Recurrency rule](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html)
+    - `frequency?` : {number} [Frequency of recurrence](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html)
+    - `until?` : {date} Date of [end of reccurence](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) specified with frequency
 - `label?` : {string} [Event description](https://icalendar.org/iCalendar-RFC-5545/3-8-1-5-description.html)
 - `description?` : {string} [Event comment](https://icalendar.org/iCalendar-RFC-5545/3-8-1-4-comment.html)
 - `location?` : {string} [Event location](https://icalendar.org/iCalendar-RFC-5545/3-8-1-7-location.html)
@@ -25,8 +26,10 @@ The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://d
   "start": "2018-01-02T20:38:04Z",
   "end": "2018-01-02T20:38:04Z",
   "timezone": "Europe/Paris",
-  "frequency": "weekly",
-  "until": "2018-01-02T20:38:04Z",
+  "rrule": {
+    "frequency": "weekly",
+    "until": "2018-01-02T20:38:04Z",
+  }
   "label": "history-geography"
   "location": "B209 BIS",
   "organizer": "Mme. Dubois",

--- a/docs/io.cozy.calendar.md
+++ b/docs/io.cozy.calendar.md
@@ -1,0 +1,54 @@
+[Table of contents](README.md#table-of-contents)
+    
+# Cozy Calendar doctype
+
+## `io.cozy.calendar`
+
+The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://datatracker.ietf.org/doc/html/rfc5545), in that some of the attributes have been renamed for clarity. The attributes with a `?` are optional.
+
+- `start?` : {date} (example: `"1959-05-15"`)
+- `end?` : {date} (example: `"1959-05-15"`)
+- `label?` : {string}
+- `description?` : {string}
+- `location?` : {string}
+- `organiser?` : {string}
+- `status?` : {string} `CONFIRMED|CANCELLED`
+- `attendee?` : {object} Array of string with event attendees
+
+### Example
+```json
+{
+  "_id": "62e5d66d6e11d19992b7efce794263f0",
+  "start": "20170422T010000",
+  "end": "20170422T010000",
+  "label": "history-geography"
+  "location": "B209 BIS",
+  "organizer": "Mme. Dubois",
+  "status": "CONFIRMED",
+  "attendee": ["TG3", "1G4"],
+  "description": "Apportez vos manuels !"
+}
+```
+
+## `io.cozy.calendar.event`
+Used to save calendar event data, to be shown in a timetable or to save past time related activities.
+
+- `start` : {date} (example: `"1959-05-15"`)
+- `end` : {date} (example: `"1959-05-15"`)
+- `label` : {string}
+
+## `io.cozy.calendar.todos`
+Used to save and retrieve to-do items
+
+- `dueDate` : {date} (example: `"1959-05-15"`)
+- `summary` : {string}
+- `completed` : {boolean}
+
+## `io.cozy.calendar.presence`
+Used to  track attendance and presence related events
+
+- `start` : {date} (example: `"1959-05-15"`)
+- `end` : {date} (example: `"1959-05-15"`)
+- `label?` : {string}
+- `justified?` : {boolean}
+- `type` : {string} `delay | absence | observation`

--- a/docs/io.cozy.calendar.md
+++ b/docs/io.cozy.calendar.md
@@ -30,7 +30,7 @@ The `io.cozy.calendar` doctype is loosely based on the [iCalendar RFC](https://d
 }
 ```
 
-## `io.cozy.calendar.event`
+## `io.cozy.calendar.events`
 Used to save calendar event data, to be shown in a timetable or to save past time related activities.
 
 - `start` : {date} (example: `"1959-05-15"`)

--- a/docs/io.cozy.timeseries.md
+++ b/docs/io.cozy.timeseries.md
@@ -42,3 +42,65 @@ These time series follow the [GeoJSON](https://geojson.org/) format. See [here](
 }
 
 ```
+
+## `io.cozy.timeseries.grades`
+This time series is used to represent a collection of grades in a given subject over a school period.
+
+It uses additional attributes :
+- `subject`: {string} The school subject these grades are referring to 
+- `title`: {string} The period (trimester or semester) name
+- `aggregation`: {Array} Grades averages over this period
+	- `avgGrades`: {number} Overall average of student grades over this period
+	- `avgClass`: {number} Overall average of class grades over this period
+	- `maxClass`: {number} Highest student overall average in the class
+	- `minClass`: {number} Lowest student overall average in the class
+- `series`: {Array} Contains the grades
+	- `id`: {string} Unique identifier for the grade
+	- `label`: {string} Grade label
+	- `date`: {date} Date of the grade
+	- `value`: {Array}
+		- `student`: {number} Student grade
+		- `outOf`: {number} Grade notation highest limit
+		- `coef`: {number} Coefficient of this grade
+		- `classAverage`: {number} Class average for this grade
+		- `classMax`: {number} Highest grading value in the class
+		- `classMin`: {number} Lowest grading value in the class
+- `status`: {Array}
+	- `isBonus`: {boolean} Is the grade counted only if it enhances the student’s average ?
+	- `isOptional`: {boolean} Is the grade an optional subject ?
+
+### Example
+```json
+
+{
+  "_id": "62e5d66d6e11d19992b7efce794263f0",
+  "subject": "hisgeo",
+  "title": "Semestre 2",
+  "startDate": "2017-04-22T01:00:00-05:00",  "endDate": "2017-07-01T01:00:00-05:00",
+  "aggregation": {
+    "avgGrades": ...,
+    "avgClass": ...,
+    "maxClass": ...,
+    "minClass": ...,
+  },
+  "series": [
+    {
+      "id": "1d16d6e192b7efce762e5d64263f0999",
+      "label": ...,
+      "date": "2017-04-22T01:00:00-05:00",
+      "value": {
+        "student": 16.00,
+        "outOf": 20.00,
+        "coef": 1.00,
+        "classAverage": 14.00,
+        "classMax": 19.00,
+        "classMin": 5.00,
+      },
+      "status": {
+        "isBonus": false,
+        "isOptional": false,
+      }
+    }
+  ],
+}
+```

--- a/docs/io.cozy.timeseries.md
+++ b/docs/io.cozy.timeseries.md
@@ -76,7 +76,8 @@ It uses additional attributes :
   "_id": "62e5d66d6e11d19992b7efce794263f0",
   "subject": "hisgeo",
   "title": "Semestre 2",
-  "startDate": "2017-04-22T01:00:00-05:00",  "endDate": "2017-07-01T01:00:00-05:00",
+  "startDate": "2017-04-22T01:00:00-05:00",
+  "endDate": "2017-07-01T01:00:00-05:00",
   "aggregation": {
     "avgGrades": ...,
     "avgClass": ...,

--- a/toc.yml
+++ b/toc.yml
@@ -4,6 +4,7 @@
 - App suggestions: ./docs/io.cozy.apps.suggestions.md
 - Banking doctypes: ./docs/io.cozy.bank.md
 - Bills: ./docs/io.cozy.bills.md
+- Calendar: ./docs/io.cozy.calendar.md
 - Connectors: ./docs/io.cozy.konnectors.md
 - CoachCO2: ./docs/io.cozy.coachco2.md
 - Contacts: ./docs/io.cozy.contacts.md


### PR DESCRIPTION
Added the `io.cozy.calendar` doctype and added `io.cozy.timeseries.grades` to the timeseries doctype as this is required for [Pronote konnector](https://github.com/konnectors/pronote).

Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [x] in the `Readme.md` index page
- [x] in the `toc.yml` page

> **Note**
> Needs merging of https://github.com/cozy/cozy-store/pull/916

- [x] https://github.com/cozy/cozy-store/blob/master/src/locales/en.json
- [x] https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json
- [x] https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions

> **Note**
> Needs merging of https://github.com/cozy/cozy-client/pull/1515

- [x] https://github.com/cozy/cozy-client/tree/master/packages/cozy-client/src/models/doctypes/locales

> **Note**
> Needs merging of https://github.com/cozy/cozy-stack/pull/4452

- [x] https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po
- [x] https://github.com/cozy/cozy-stack/blob/master/assets/styles/cirrus.css

