### PR TITLE
docs: Add the io.cozy.ai.chat.conversations doctype

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ for another doctype, feel free to open a PR with the description and role of you
 ## Cozy doctypes
 
 - [io.cozy.accounts](io.cozy.accounts.md): Konnector accounts
+- [io.cozy.ai.chat.conversations](io.cozy.ai.chat.conversations.md): Chat conversations with an assistant (AI)
 - [io.cozy.apps](io.cozy.apps.md): Apps installed in the Cozy
   - [io.cozy.apps.suggestions](io.cozy.apps.suggestions.md): Suggestions for apps that the user might find useful
 - [io.cozy.bank](io.cozy.bank.md): Banking related data

--- a/docs/io.cozy.ai.chat.conversations.md
+++ b/docs/io.cozy.ai.chat.conversations.md
@@ -1,0 +1,57 @@
+[Table of contents](README.md#table-of-contents)
+
+# Chat conversations with an AI
+
+Cf [the stack documentation for AI](https://docs.cozy.io/en/cozy-stack/ai/).
+
+## `io.cozy.ai.chat.conversations`
+
+The `io.cozy.ai.chat.conversations` doctype is used to keep history of chat
+conversations with an assistant (AI).
+
+- `messages`: {array} An array of the messages of a conversation
+  - `id`: {string} Identifier of the message
+  - `role`: {string} Can be `user` or `assistant`
+  - `content`: {string} What was said by the user or the assistant
+  - `createdAt`: {date} When the message was published
+
+### Example
+
+
+```json
+{
+  "_id": "e21dce8058b9013d800a18c04daba326",
+  "_rev": "1-23456",
+  "cozyMetadata": {
+    "createdAt": "2024-09-24T13:24:07.576Z",
+    "createdOn": "http://cozy.localhost:8080/",
+    "doctypeVersion": "1",
+    "metadataVersion": 1,
+    "updatedAt": "2024-09-24T13:24:07.576Z"
+  },
+  "messages": [
+    {
+      "id": "eb17c3205bf1013ddea018c04daba326",
+      "role": "user",
+      "content": "Why the sky is blue?",
+      "createdAt": "2024-09-24T13:24:07.576Z"
+    },
+    {
+      "id": "0192756f2428758abe0aec7ecefc0c60",
+      "content": "The sky appears blue because of a phenomenon called Rayleigh scattering.",
+      "createdAt": "2024-09-24T13:24:08.987Z",
+      "role": "assistant"
+    }
+  ]
+}
+```
+
+### `io.cozy.ai.chat.events`
+
+This doctype is not persisted, it is only used on the realtime websockets to
+allow the application to display the tokens of the response step by step.
+
+- `id`: {string} the identifier of the message of the user (the question)
+- `object`: {string} can be `delta` for a token or `done` when it's finished
+- `content`: {string} the content of the token
+- `position`: {int} the index of the token in the stream (as the events can be received in the wrong order)

--- a/toc.yml
+++ b/toc.yml
@@ -1,5 +1,6 @@
 - README: ./docs/README.md
 - Accounts: ./docs/io.cozy.accounts.md
+- AI: ./docs/io.cozy.ai.chat.conversations.md
 - Apps: ./docs/io.cozy.apps.md
 - App suggestions: ./docs/io.cozy.apps.suggestions.md
 - Banking doctypes: ./docs/io.cozy.bank.md


### PR DESCRIPTION
Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [ ] in the `Readme.md` index page
- [ ] in the `toc.yml` page
- [ ] https://github.com/cozy/cozy-store/blob/master/src/locales/en.json
- [ ] https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json
- [ ] https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions
- [ ] https://github.com/cozy/cozy-client/tree/master/packages/cozy-client/src/models/doctypes/locales
- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po
- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/styles/cirrus.css
