### PR TITLE
fix letsgone remote doctype

### DIFF
--- a/org.letsgone.api/request
+++ b/org.letsgone.api/request
@@ -1,1 +1,1 @@
-GET https://letsgone.grandlyon.com/wp-json
+GET https://letsgone.grandlyon.com/wp-json/{{ressource}}


### PR DESCRIPTION
I messed up my first PR

Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [ ] in the `Readme.md` index page
- [ ] in the `toc.yml` page
- [ ] https://github.com/cozy/cozy-store/blob/master/src/locales/en.json
- [ ] https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json
- [ ] https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions
- [ ] https://github.com/cozy/cozy-client/tree/master/packages/cozy-client/src/models/doctypes/locales
- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po
- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/styles/cirrus.css
