### PR TITLE
docs(io.cozy.files): Add `hideOOEditTooltip` attribute

### DIFF
--- a/docs/io.cozy.files.md
+++ b/docs/io.cozy.files.md
@@ -399,6 +399,7 @@ fields), and a relationship to the versioned file.
 This doctype is used to store settings for files. It is currenly only used for the qualification migration service.
 
 - lastProcessedFileDate: {string} the `cozyMetadata.updatedAt` date of the last processed file. It is used to know from where the query should be starting on an index sorted by date.
+- hideOOEditTooltip: {boolean} Is used to determine whether the tooltip of an Open Office file's edit button should be displayed.
 
 ## `io.cozy.files.encryption`
 


### PR DESCRIPTION
Ref: https://github.com/cozy/cozy-drive/pull/3310