### PR TITLE
docs: Add phone_number field to instance settings doctype

### DIFF
--- a/docs/io.cozy.settings.md
+++ b/docs/io.cozy.settings.md
@@ -14,6 +14,7 @@ is the stack instance-related settings.
 - `tz`: {string} Timezone of the instance (ex: `Europe/Paris`)
 - `email`: {string} Email of the instance
 - `public_name`: {string} Public displayed name of the instance
+- `phone_number`: {string} Phone number of the instance
 - `default_redirection`: {string} Redirect to an app after login (ex: `drive/#/folder`)
 - `colorScheme`: {'light'|'dark'|'auto} Used to manage the appearance of an app
 


### PR DESCRIPTION
The phone_number field has been added to the io.cozy.settings.instance doctype to store user's phone number for profile information.

Relates to the implementation in profile view where users can now add their phone number to their Cozy profile.

Thanks for contributing to this documentation. If you added a doctype, please be sure that it is present 

- [ ] in the `Readme.md` index page
- [ ] in the `toc.yml` page
- [ ] https://github.com/cozy/cozy-store/blob/master/src/locales/en.json
- [ ] https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json
- [ ] https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions
- [ ] https://github.com/cozy/cozy-client/tree/master/packages/cozy-client/src/models/doctypes/locales
- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po
- [ ] https://github.com/cozy/cozy-stack/blob/master/assets/styles/cirrus.css
